### PR TITLE
Add tenancy support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# Description
+
+> *For `description`, provide a brief explanation of the context around this change.*
+
+## Verification
+
+> *Include screenshots, log messages, etc. to show how this change  was tested/verified.*
+
+## Ready for Code Review Checklist
+
+- [ ] Includes unit tests
+- [ ] Includes related documentation

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: 🛠 Breaking Changes 🛠
+      labels:
+        - Version-Major
+    - title: 🎉 Enhancements 🎉
+      labels:
+        - Version-Minor
+    - title: 🩹 Patches 🩹
+      labels:
+        - Version-Patch
+    - title: 📖 Documentation 📖
+      labels:
+        - documentation
+    - title: 🤷 Other Changes 🤷
+      labels:
+        - "*"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ jobs:
 ## Inputs
 
 ### `test`
+
 **Required** The ID of the test you wish to execute.
 
 ### `location`
+
 **Required** The location the test will be executed in. Options:
 
 - `AWS-US-EAST-1` : N. Virginia
@@ -43,25 +45,39 @@ jobs:
 - `AWS-SA-EAST-1` : São Paulo
 
 ### `environment`
+
 The environment you want to run the test in. If you don't use environment omit this parameter
 
 ### `tenant`
 
-The tenant to run the test against. Defaults to the public Hub `rapidapi.com`.
+The tenant to run the test against. Defaults to the public Hub `rapidapi.com`. For example for an enterprise
+it may be `tenant: ${ENTERPRISE_DOMAIN}.hub.rapidapi.com`. Likewise, for different regions:
 
+```yaml
+US: https://acme.hub.rapidapi.com
+CA: https://acme.hub-ca.rapidapi.com
+EU: https://acme.hub-eu.rapidapi.com
+```
+
+With `acme` being a mock domain used as an example.
 ## Outputs
 
 ### `time`
+
 The time it took the test to execute, in milliseconds (1000ms=s)
 
 ### `successful`
+
 True/false based on the result of the test execution
 
 ### `reportUrl`
+
 URL of a human-readable report of the test execution
 
 ### `computedStatus`
+
 A human-readable test status that matches the status values on the test dashboard in the UI
 
 ## Help
+
 For any help using this integration, reach out to `support@rapidapi.com`. You can also see RapidAPI Testing Guide in our [Help Center](https://docs.rapidapi.com/docs/creating-test-flows).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RapidAPI Testing GitHub Actions
 
-This GitHub Action allows you to trigger the execution of [RapidAPI Testing](https://rapidapi.com/testing) tests.
+This GitHub Action allows you to trigger the execution of [RapidAPI Testing](https://rapidapi.com/testing) tests. This is especially useful
+during CI/CD to ensure new deployments are functioning as expected.
 
 ## Complete example
 
@@ -44,6 +45,10 @@ jobs:
 ### `environment`
 The environment you want to run the test in. If you don't use environment omit this parameter
 
+### `tenant`
+
+The tenant to run the test against. Defaults to the public Hub `rapidapi.com`.
+
 ## Outputs
 
 ### `time`
@@ -59,4 +64,4 @@ URL of a human-readable report of the test execution
 A human-readable test status that matches the status values on the test dashboard in the UI
 
 ## Help
-For any help using this integration, reach out to `support@rapidapi.com`. You can also see RapidAPI Testing Guide in our [Help Center](https://docs.rapidapi.com/docs/creating-test-flows). 
+For any help using this integration, reach out to `support@rapidapi.com`. You can also see RapidAPI Testing Guide in our [Help Center](https://docs.rapidapi.com/docs/creating-test-flows).

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'The location the test will be executed in'
     required: true
     default: 'AWS-US-EAST-1'
+  tenant:
+    description: 'The Rapid tenant to run the tests against'
+    required: false
+    default: 'rapidapi.com'
   environment:
     description: 'The environment ID the test will run in'
     required: false
@@ -22,5 +26,5 @@ outputs:
   reportUrl:
     description: 'Url for the full test execution URL'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -6,9 +6,13 @@ const axios = require('axios');
 const WAIT_TIME = 1000;
 const MAX_TRIES = 300;
 const FIRST_WAIT = 2000;
-const API_URL = "https://rapidapi.com/testing/api/trigger";
+const API_URL = (tenant) => {"https://${tenant}/testing/api/trigger"}
 
 // INPUTS
+
+const TENANT = core.getInput('tenant');
+console.log(`Executing Test Against Tenant: ${API_URL}`);
+
 const TEST_ID = core.getInput('test');
 console.log(`Executing Test ID: ${TEST_ID}`);
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const axios = require('axios');
 const WAIT_TIME = 1000;
 const MAX_TRIES = 300;
 const FIRST_WAIT = 2000;
-const API_URL = (tenant) => {"https://${tenant}/testing/api/trigger"}
+const api_url = (tenant) => {"https://${tenant}/testing/api/trigger"}
 
 // INPUTS
 
@@ -34,7 +34,7 @@ function sleep(time) {
 core.group('Execute Test', async () => {
     // 1. Trigger Test
     const envString = ENVIRONMENT ? `&enviroment=${ENVIRONMENT}` : '';
-    const testTrigger = (await axios.get(`${API_URL}/test/${TEST_ID}/execute?source=gh_action&location=${LOCATION}${envString}`)).data;
+    const testTrigger = (await axios.get(`${api_url(TENANT)}/test/${TEST_ID}/execute?source=gh_action&location=${LOCATION}${envString}`)).data;
     const reportUrl = testTrigger.reportUrl;
     console.log(testTrigger.message);
     core.setOutput("reportUrl", reportUrl);
@@ -50,7 +50,7 @@ core.group('Execute Test', async () => {
         tries < MAX_TRIES // safety
     ) {
         await sleep(WAIT_TIME);
-        testResult = (await axios.get(`${API_URL}/execution/${executionId}/status`)).data;
+        testResult = (await axios.get(`${api_url(TENANT)}/execution/${executionId}/status`)).data;
     }
     delete testResult.report;
     console.log(testResult);

--- a/index.js
+++ b/index.js
@@ -6,13 +6,8 @@ const axios = require('axios');
 const WAIT_TIME = 1000;
 const MAX_TRIES = 300;
 const FIRST_WAIT = 2000;
-const api_url = (tenant) => {"https://${tenant}/testing/api/trigger"}
 
 // INPUTS
-
-const TENANT = core.getInput('tenant');
-console.log(`Executing Test Against Tenant: ${API_URL}`);
-
 const TEST_ID = core.getInput('test');
 console.log(`Executing Test ID: ${TEST_ID}`);
 
@@ -22,6 +17,8 @@ console.log(`Executing In Location: ${LOCATION}`);
 const ENVIRONMENT = core.getInput('environment') || null;
 console.log(`Executing In Env: ${ENVIRONMENT}`);
 
+const API_URL = `https://${core.getInput('tenant')}/testing/api/trigger`;
+console.log(`Executing Test Against: ${API_URL}`);
 
 function sleep(time) {
     return new Promise((res, rej) => {
@@ -34,7 +31,7 @@ function sleep(time) {
 core.group('Execute Test', async () => {
     // 1. Trigger Test
     const envString = ENVIRONMENT ? `&enviroment=${ENVIRONMENT}` : '';
-    const testTrigger = (await axios.get(`${api_url(TENANT)}/test/${TEST_ID}/execute?source=gh_action&location=${LOCATION}${envString}`)).data;
+    const testTrigger = (await axios.get(`${API_URL}/test/${TEST_ID}/execute?source=gh_action&location=${LOCATION}${envString}`)).data;
     const reportUrl = testTrigger.reportUrl;
     console.log(testTrigger.message);
     core.setOutput("reportUrl", reportUrl);
@@ -50,7 +47,7 @@ core.group('Execute Test', async () => {
         tries < MAX_TRIES // safety
     ) {
         await sleep(WAIT_TIME);
-        testResult = (await axios.get(`${api_url(TENANT)}/execution/${executionId}/status`)).data;
+        testResult = (await axios.get(`${API_URL}}/execution/${executionId}/status`)).data;
     }
     delete testResult.report;
     console.log(testResult);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ core.group('Execute Test', async () => {
         tries < MAX_TRIES // safety
     ) {
         await sleep(WAIT_TIME);
-        testResult = (await axios.get(`${API_URL}}/execution/${executionId}/status`)).data;
+        testResult = (await axios.get(`${API_URL}/execution/${executionId}/status`)).data;
     }
     delete testResult.report;
     console.log(testResult);

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "": {
-      "name": "RapidAPI-testing-github-action",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@actions/core": "^1.2.6",
-        "@actions/github": "^4.0.0",
-        "axios": "^0.20.0"
-      }
-    },
     "node_modules/@actions/core": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RapidAPI-testing-github-action",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Executes RapidAPI tests as a GitHub action",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "RapidAPI-testing-github-action",
-  "version": "0.0.3",
-  "description": "",
+  "version": "0.0.4",
+  "description": "Executes RapidAPI tests as a GitHub action",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
# Description

Adds support for the the testing GitHub action to support multi-tenancy test execution. Node version for execution bumped to 16 for my sanity.

## Verification

Created dummy test in the prodca Hub and executed against this action using
```yaml 
jobs:
  run_api_test:
    runs-on: ubuntu-latest
    name: Execute RapidAPI API Tests
    steps:
    - name: Execute Tests
      id: tstExec
      uses: RapidAPI/gh-api-testing-trigger@add-tenancy-support
      with:
        test: 'test_bbdc3526-0073-432a-9d30-a8629596c08d'
        location: 'AWS-US-EAST-1'
        tenant: "rapidapi.hub-ca.rapidapi.com"
    - name: Show Results
      run: echo "The test took ${{ steps.tstExec.outputs.time }}ms to run"; echo "The test result was ${{ steps.tstExec.outputs.computedStatus }}"; echo "View Report - ${{ steps.tstExec.outputs.reportUrl }}"
```

![Screen Shot 2023-03-17 at 3 08 25 PM](https://user-images.githubusercontent.com/106683658/226061824-af1ec04f-a04e-4161-acef-2d3abe403f9e.png)

![Screen Shot 2023-03-17 at 3 11 53 PM](https://user-images.githubusercontent.com/106683658/226061988-92c2a3ba-a960-4a4e-8ced-e3cdfb5ae5d7.png)


## Ready for Code Review Checklist

- [ ] Includes unit tests
- [x] Includes related documentation